### PR TITLE
Update plot colourschemes and simplify plotting arguments

### DIFF
--- a/R/histline.R
+++ b/R/histline.R
@@ -21,7 +21,7 @@
 #' @importFrom graphics plot box
 histline <- function(height, breaks, lineonly=FALSE, outline=FALSE,
                      ylim=range(height), xlab="x", ylab="y", det.plot=FALSE,
-                     add=FALSE,...){
+                     add=FALSE, ...){
 
   # make hist object
   hh <- list()

--- a/R/plot.det.tables.R
+++ b/R/plot.det.tables.R
@@ -4,19 +4,29 @@
 #' tables for dual observer data that shows the number missed and detected for
 #' each observer within defined distance classes.
 #'
+#' Plots that are produced are as follows (controlled by the \code{which} argument):
+#' \describe{
+#'   \item{1}{Detected by either observer/Detected by observer 1}
+#'   \item{2}{Detected by either observer/Detected by observer 2}
+#'   \item{3}{Seen by both observers}
+#'   \item{4}{Seen by either observer}
+#'   \item{5}{Detected by observer 2/Detected by observer 1 | 2}
+#'   \item{6}{Detected by observer 1/Detected by observer 2 | 1}
+#' }
+#'
+#'
 #' @aliases plot.det.tables
 #' @export
 #' @param x object returned by \code{\link{det.tables}}
 #' @param which items in x to plot (vector with values in 1:6)
 #' @param angle shading angle for hatching
 #' @param density shading density for hatching
-#' @param col1 plotting colour for observer 1 detections
-#' @param col2 plotting colour for observer 2 detections within observer 1
-#'  subset detections
-#' @param new if TRUE new plotting window for each plot
+#' @param col1 plotting colour for total histogram bars.
+#' @param col2 plotting colour for subset histogram bars.
+#' @param new if \code{TRUE} new plotting window for each plot
 #' @param \dots other graphical parameters, passed to plotting functions
 #' @return Just plots.
-#' @author Jeff Laake
+#' @author Jeff Laake, David L Miller
 #' @importFrom grDevices dev.new
 #' @importFrom graphics legend
 #' @examples
@@ -33,55 +43,62 @@
 #' par(mfrow=c(2,3))
 #' plot(tabs,which=1:6,new=FALSE)
 #' }
-plot.det.tables <- function(x,which=1:6,angle=-45,density=20,col1="black",
-                            col2="blue", new=TRUE,...){
+plot.det.tables <- function(x, which=1:6, angle=NULL, density=NULL,
+                            col1="white", col2="lightgrey", new=TRUE,...){
 
   # plotting function that actually does the work
-  plot_seen <- function(x,col1,col2,leg.title,...){
-    if(new& .Platform$GUI=="Rgui")dev.new()
-    missed <- x[,"Missed"]
-    detected <- x[,"Detected"]
+  plot_seen <- function(x, col1, col2, leg.title, ...){
+    if(new & .Platform$GUI=="Rgui") dev.new()
+    missed <- x[, "Missed"]
+    detected <- x[, "Detected"]
     ymax <- max(missed+detected)
-    histline(detected,breaks=breaks,lineonly=FALSE,ylim=c(0,ymax),
-             xlab="Distance",ylab="Frequency",angle=angle,
-             density=density,col=col2,...)
-    histline(missed+detected,breaks,lineonly=TRUE,col=col1,add=TRUE,
-             density=0,det.plot=TRUE,...)
-    legend("topright",legend=leg.title,lty=1,lwd=3,col=c(col1,col2))
+
+    # plot "background" total
+    histline(missed+detected, breaks=breaks, lineonly=TRUE, ylim=c(0, ymax),
+             xlab="Distance", ylab="Frequency", angle=angle,
+             density=density, col=col1, add=FALSE, ...)
+
+    # plot "foreground" detected
+    histline(detected, breaks, lineonly=TRUE, col=col2, add=TRUE,
+             density=density, det.plot=TRUE, ...)
+
+    legend("topright", legend=leg.title, fill=c(col1, col2))
   }
 
   breaks <- x$breaks
 
-  if(is.element(1,which)&!is.null(x$Observer1)){
+  if(is.element(1, which) & !is.null(x$Observer1)){
     plot_seen(x$Observer1, col1, col2, c("Detected by either observer",
                                          "Detected by observer 1"), ...)
   }
 
-  if(is.element(2,which)&!is.null(x$Observer2)){
+  if(is.element(2, which) & !is.null(x$Observer2)){
     plot_seen(x$Observer2, col1, col2, c("Detected by either observer",
                                          "Detected by observer 2"), ...)
   }
 
-  if(is.element(3,which)&!is.null(x$Duplicates)){
+  if(is.element(3, which) & !is.null(x$Duplicates)){
+    ymax <- max(x$Duplicates)
     histline(x$Duplicates, breaks=breaks, lineonly=FALSE, xlab="Distance",
-             ylab="Frequency", angle=angle, density=density, col=col1, ...)
-    legend("topright", legend=c("Seen by both observers"), lty=1, lwd=3,
-           col=c(col1))
+             ylab="Frequency", angle=angle, density=density, col=col1,
+             ylim=c(0, ymax), ...)
+    legend("topright", legend=c("Seen by both observers"), fill=c(col1))
   }
 
-  if(is.element(4,which)&!is.null(x$Pooled)){
+  if(is.element(4, which) & !is.null(x$Pooled)){
+    ymax <- max(x$Pooled)
     histline(x$Pooled, breaks=breaks, lineonly=FALSE, xlab="Distance",
-             ylab="Frequency", angle=angle, density=density, col=col1, ...)
-    legend("topright", legend=c("Seen by either observer"), lty=1, lwd=3,
-           col=c(col1))
+             ylab="Frequency", angle=angle, density=density, col=col1,
+             ylim=c(0, ymax), ...)
+    legend("topright", legend=c("Seen by either observer"), fill=c(col1))
   }
 
-  if(is.element(5,which)&!is.null(x$Obs1_2)){
+  if(is.element(5, which) & !is.null(x$Obs1_2)){
     plot_seen(x$Obs1_2, col1, col2, c("Detected by observer 2",
                                       "Detected by observer 1 | 2"), ...)
   }
 
-  if(is.element(6,which)&!is.null(x$Obs2_1)){
+  if(is.element(6, which) & !is.null(x$Obs2_1)){
     plot_seen(x$Obs2_1, col1, col2, c("Detected by observer 1",
                                       "Detected by observer 2 | 1"), ...)
   }

--- a/R/plot.io.R
+++ b/R/plot.io.R
@@ -35,10 +35,10 @@
 #'   observation
 #' @param showlines logical variable; if TRUE a line representing the average
 #'   detection probability is plotted
-#' @param ylim range of y axis; defaults to (0,1)
-#' @param angle shading angle for hatching
-#' @param density shading density for hatching
-#' @param col plotting colour
+#' @param ylim range of vertical axis; defaults to (0,1)
+#' @param angle shading angle for histogram bars.
+#' @param density shading density for histogram bars.
+#' @param col colour for histogram bars.
 #' @param jitter scaling option for plotting points.  Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter.
@@ -70,10 +70,10 @@
 #' plot(result.io,which=c(1,2,5,6),pages=2)
 #' }
 plot.io <- function(x, which=1:6, breaks=NULL, nc=NULL,  maintitle="",
-                    showlines=TRUE, showpoints=TRUE,ylim=c(0,1),angle=-45,
-                    density=20,col="black",jitter=NULL,divisions=25,pages=0,
-                    xlab="Distance",ylab="Detection probability",subtitle=TRUE,
-                    ...){
+                    showlines=TRUE, showpoints=TRUE, ylim=c(0, 1), angle=NULL,
+                    density=NULL, col="lightgrey", jitter=NULL, divisions=25,
+                    pages=0, xlab="Distance", ylab="Detection probability",
+                    subtitle=TRUE, ...){
 
   model <- x
 

--- a/R/plot.io.R
+++ b/R/plot.io.R
@@ -39,7 +39,7 @@
 #' @param angle shading angle for histogram bars.
 #' @param density shading density for histogram bars.
 #' @param col colour for histogram bars.
-#' @param jitter scaling option for plotting points.  Jitter is applied to
+#' @param jitter scaling option for plotting points. Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter.
 #' @param divisions number of divisions for averaging line values; default = 25

--- a/R/plot.io.fi.R
+++ b/R/plot.io.fi.R
@@ -36,10 +36,10 @@
 #'   observation
 #' @param showlines logical variable; if TRUE a line representing the average
 #'   detection probability is plotted
-#' @param ylim range of y axis; defaults to (0,1)
-#' @param angle shading angle for hatching
-#' @param density shading density for hatching
-#' @param col plotting colour
+#' @param ylim range of vertical axis; defaults to (0,1)
+#' @param angle shading angle for histogram bars.
+#' @param density shading density for histogram bars.
+#' @param col colour for histogram bars.
 #' @param jitter scaling option for plotting points.  Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter.
@@ -71,8 +71,9 @@
 #' plot(result.io.fi,which=c(1,2,5,6),pages=2)
 #' }
 plot.io.fi <- function(x, which=1:6, breaks=NULL, nc=NULL, maintitle="",
-                       showlines=TRUE, showpoints=TRUE,ylim=c(0,1),angle=-45,
-                       density=20,col="black",jitter=NULL,divisions=25,pages=0,
+                       showlines=TRUE, showpoints=TRUE, ylim=c(0, 1),
+                       angle=NULL, density=NULL, col="lightgrey", jitter=NULL,
+                       divisions=25, pages=0,
                        xlab="Distance",ylab="Detection probability",
                        subtitle=TRUE,...){
   # Functions used: process.data, predict.io.fi, plot_uncond,plot_cond

--- a/R/plot.rem.R
+++ b/R/plot.rem.R
@@ -27,14 +27,14 @@
 #' @param breaks user define breakpoints
 #' @param nc number of equal-width bins for histogram
 #' @param maintitle main title line for each plot
-#' @param showpoints logical variable; if TRUE plots predicted value for each
+#' @param showpoints logical variable; if \code{TRUE} plots predicted value for each
 #'   observation
-#' @param showlines logical variable; if TRUE a line representing the average
+#' @param showlines logical variable; if \code{TRUE} a line representing the average
 #'   detection probability is plotted
-#' @param ylim range of y axis; defaults to (0,1)
-#' @param angle shading angle for hatching
-#' @param density shading density for hatching
-#' @param col plotting colour
+#' @param ylim range of vertical axis; defaults to (0,1)
+#' @param angle shading angle for histogram bars.
+#' @param density shading density for histogram bars.
+#' @param col colour for histogram bars.
 #' @param jitter scaling option for plotting points.  Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter.
@@ -44,17 +44,18 @@
 #' @param divisions number of divisions for averaging line values; default = 25
 #' @param xlab label for x-axis
 #' @param ylab label for y-axis
-#' @param subtitle if TRUE, shows plot type as sub-title
+#' @param subtitle if \code{TRUE}, shows plot type as sub-title
 #' @param \dots other graphical parameters, passed to the plotting functions
 #'   (\code{plot}, \code{hist}, \code{lines}, \code{points}, etc)
 #' @return NULL
 #' @author Jeff Laake, Jon Bishop, David Borchers, David L Miller
 #' @keywords plot
-plot.rem <- function(x,which=1:3,breaks=NULL,nc=NULL,maintitle="",
-                     showlines=TRUE, showpoints=TRUE,ylim=c(0,1),angle=-45,
-                     density=20,col="black",jitter=NULL,divisions=25,pages=0,
-                     xlab="Distance",ylab="Detection probability",
-                     subtitle=TRUE,...){
+plot.rem <- function(x, which=1:3, breaks=NULL, nc=NULL, maintitle="",
+                     showlines=TRUE,  showpoints=TRUE, ylim=c(0, 1), angle=NULL,
+                     density=NULL, col="lightgrey", jitter=NULL, divisions=25,
+                     pages=0,
+                     xlab="Distance", ylab="Detection probability",
+                     subtitle=TRUE, ...){
 
   model <- x
 
@@ -64,14 +65,14 @@ plot.rem <- function(x,which=1:3,breaks=NULL,nc=NULL,maintitle="",
   xmat.p0$distance <- 0
   ddfobj <- model$ds$ds$aux$ddfobj
   if(ddfobj$type=="gamma"){
-    xmat.p0$distance <- rep(apex.gamma(ddfobj),2)
+    xmat.p0$distance <- rep(apex.gamma(ddfobj), 2)
   }
-  p0 <- predict(model$mr,newdata=xmat.p0,integrate=FALSE)$fitted
+  p0 <- predict(model$mr, newdata=xmat.p0, integrate=FALSE)$fitted
   xmat <- model$mr$data
-  cond.det <- predict(model$mr,newdata=xmat,integrate=FALSE)
+  cond.det <- predict(model$mr, newdata=xmat, integrate=FALSE)
   width <- model$meta.data$width
   left <- model$meta.data$left
-  detfct.pooled.values <- detfct(xmat$distance[xmat$observer==1],ddfobj,
+  detfct.pooled.values <- detfct(xmat$distance[xmat$observer==1], ddfobj,
                                  width=width-left)
   delta <- cond.det$fitted/(p0*detfct.pooled.values)
   p1 <- cond.det$p1
@@ -100,32 +101,33 @@ plot.rem <- function(x,which=1:3,breaks=NULL,nc=NULL,maintitle="",
   on.exit(devAskNewPage(oask))
 
   # Plot primary unconditional detection function
-  if(is.element(1,which)){
-    plot_uncond(model,1,xmat,gxvalues=p1/delta,nc,
+  if(is.element(1, which)){
+    plot_uncond(model, 1, xmat, gxvalues=p1/delta, nc,
                 finebr=(width/divisions)*(0:divisions),
-                breaks,showpoints,showlines,maintitle,ylim,
-                angle=angle,density=density,
-                col=col,jitter=jitter,xlab=xlab,ylab=ylab,subtitle=subtitle,...)
+                breaks, showpoints, showlines, maintitle, ylim,
+                angle=angle, density=density,
+                col=col, jitter=jitter, xlab=xlab, ylab=ylab, subtitle=subtitle,
+                ...)
   }
 
   # Plot pooled unconditional detection function
-  if(is.element(2,which)){
-    plot_uncond(model,3,xmat,gxvalues=(p1+p2*(1-p1))/delta,nc,
-                finebr=(width/divisions)*(0:divisions),breaks,showpoints,
-                showlines,maintitle,ylim,
-                angle=angle,density=density,col=col,jitter=jitter,
-                xlab=xlab,ylab=ylab,subtitle=subtitle,...)
+  if(is.element(2, which)){
+    plot_uncond(model, 3, xmat, gxvalues=(p1+p2*(1-p1))/delta, nc,
+                finebr=(width/divisions)*(0:divisions), breaks, showpoints,
+                showlines, maintitle, ylim,
+                angle=angle, density=density, col=col, jitter=jitter,
+                xlab=xlab, ylab=ylab, subtitle=subtitle, ...)
   }
 
   # Plot conditional detection function
   data <- process.data(model$mr$data,model$meta.data)$xmat
   data$offsetvalue <- 0
-  if(is.element(3,which)){
+  if(is.element(3, which)){
     gxvalues <- p1[xmat$detected[xmat$observer==2]==1]
-    plot_cond(1,data,gxvalues,model,nc,breaks,
-              finebr=(width/divisions)*(0:divisions),showpoints,showlines,
-              maintitle,ylim,angle=angle,density=density,col=col,jitter=jitter,
-              xlab=xlab,ylab=ylab,subtitle=subtitle,...)
+    plot_cond(1, data, gxvalues, model, nc, breaks,
+              finebr=(width/divisions)*(0:divisions), showpoints, showlines,
+              maintitle, ylim, angle=angle, density=density, col=col,
+              jitter=jitter, xlab=xlab, ylab=ylab, subtitle=subtitle, ...)
   }
   invisible(NULL)
 }

--- a/R/plot.rem.fi.R
+++ b/R/plot.rem.fi.R
@@ -27,14 +27,14 @@
 #' @param breaks user defined breakpoints
 #' @param nc number of equal-width bins for histogram
 #' @param maintitle main title line for each plot
-#' @param showpoints logical variable; if TRUE plots predicted value for each
+#' @param showpoints logical variable; if \code{TRUE} plots predicted value for each
 #'   observation
-#' @param showlines logical variable; if TRUE a line representing the average
+#' @param showlines logical variable; if \code{TRUE} a line representing the average
 #'   detection probability is plotted
-#' @param ylim range of y axis; defaults to (0,1)
-#' @param angle shading angle for hatching
-#' @param density shading density for hatching
-#' @param col plotting colour
+#' @param ylim range of vertical axis; defaults to (0,1)
+#' @param angle shading angle for histogram bars.
+#' @param density shading density for histogram bars.
+#' @param col colour for histogram bars.
 #' @param jitter scaling option for plotting points.  Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter
@@ -44,17 +44,18 @@
 #'  Default is 0, which prompts the user for the next plot to be displayed.
 #' @param xlab label for x-axis
 #' @param ylab label for y-axis
-#' @param subtitle if TRUE, shows plot type as sub-title
+#' @param subtitle if \code{TRUE}, shows plot type as sub-title
 #' @param \dots other graphical parameters, passed to the plotting functions
 #'   (\code{plot}, \code{hist}, \code{lines}, \code{points}, etc)
 #' @return NULL
 #' @author Jeff Laake, Jon Bishop, David Borchers, David L Miller
 #' @keywords plot
-plot.rem.fi <- function(x,which=1:3,breaks=NULL,nc=NULL,maintitle="",
-                        showlines=TRUE, showpoints=TRUE,ylim=c(0,1),angle=-45,
-                        density=20,col="black",jitter=NULL,divisions=25,
-                        pages=0,xlab="Distance",ylab="Detection probability",
-                        subtitle=TRUE,...){
+plot.rem.fi <- function(x, which=1:3, breaks=NULL, nc=NULL, maintitle="",
+                        showlines=TRUE, showpoints=TRUE, ylim=c(0, 1),
+                        angle=NULL, density=NULL, col="lightgrey", jitter=NULL,
+                        divisions=25,
+                        pages=0, xlab="Distance", ylab="Detection probability",
+                        subtitle=TRUE, ...){
   # Functions used: process.data, predict(predict.io.fi),
   #                 plot.uncond, plot.cond
 
@@ -93,31 +94,31 @@ plot.rem.fi <- function(x,which=1:3,breaks=NULL,nc=NULL,maintitle="",
 
   # Plot primary unconditional detection function
   if(is.element(1,which)){
-    plot_uncond(model,1,xmat,gxvalues=p1,nc,
-                finebr=(width/divisions)*(0:divisions),breaks,showpoints,
-                showlines,maintitle,ylim,
-                angle=angle,density=density,col=col,jitter=jitter,
-                xlab=xlab,ylab=ylab,subtitle=subtitle,...)
+    plot_uncond(model, 1, xmat, gxvalues=p1, nc,
+                finebr=(width/divisions)*(0:divisions), breaks, showpoints,
+                showlines, maintitle, ylim,
+                angle=angle, density=density, col=col, jitter=jitter,
+                xlab=xlab, ylab=ylab, subtitle=subtitle, ...)
   }
 
   # Plot pooled unconditional detection function
-  if(is.element(2,which)){
-    plot_uncond(model,3,xmat,gxvalues=p1+p2*(1-p1),nc,
-                finebr=(width/divisions)*(0:divisions),breaks,showpoints,
-                showlines,maintitle,ylim,
-                angle=angle,density=density,col=col,jitter=jitter,
-                xlab=xlab,ylab=ylab,subtitle=subtitle,...)
+  if(is.element(2, which)){
+    plot_uncond(model, 3, xmat, gxvalues=p1+p2*(1-p1), nc,
+                finebr=(width/divisions)*(0:divisions), breaks, showpoints,
+                showlines, maintitle, ylim,
+                angle=angle, density=density, col=col, jitter=jitter,
+                xlab=xlab, ylab=ylab, subtitle=subtitle, ...)
   }
 
   # Plot conditional detection function
-  data <- process.data(model$data,model$meta.data)$xmat
+  data <- process.data(model$data, model$meta.data)$xmat
   data$offsetvalue <- 0
-  if(is.element(3,which)){
+  if(is.element(3, which)){
     gxvalues <- p1[xmat$detected[xmat$observer==2]==1]
-    plot_cond(1,data,gxvalues,model,nc,breaks,
-              finebr=(width/divisions)*(0:divisions),showpoints,showlines,
-              maintitle,ylim,angle=angle,density=density,col=col,jitter=jitter,
-              xlab=xlab,ylab=ylab,subtitle=subtitle,...)
+    plot_cond(1, data, gxvalues, model, nc, breaks,
+              finebr=(width/divisions)*(0:divisions), showpoints, showlines,
+              maintitle, ylim, angle=angle, density=density, col=col,
+              jitter=jitter, xlab=xlab, ylab=ylab, subtitle=subtitle, ...)
   }
   invisible(NULL)
 }

--- a/R/plot.trial.R
+++ b/R/plot.trial.R
@@ -26,15 +26,15 @@
 #' @param breaks user define breakpoints
 #' @param nc number of equal-width bins for histogram
 #' @param maintitle main title line for each plot
-#' @param showlines logical variable; if TRUE a line representing the average
+#' @param showlines logical variable; if \code{TRUE} a line representing the average
 #'   detection probability is plotted
-#' @param showpoints logical variable; if TRUE plots predicted value for each
+#' @param showpoints logical variable; if \code{TRUE} plots predicted value for each
 #'   observation
-#' @param ylim range of y axis; defaults to (0,1)
-#' @param angle shading angle for hatching
-#' @param density shading density for hatching
-#' @param col plotting colour
-#' @param jitter scaling option for plotting points.  Jitter is applied to
+#' @param ylim range of vertical axis; defaults to (0,1)
+#' @param angle shading angle for histogram bars.
+#' @param density shading density for histogram bars.
+#' @param col colour for histogram bars.
+#' @param jitter scaling option for plotting points. Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter.
 #' @param divisions number of divisions for averaging line values; default = 25
@@ -43,17 +43,18 @@
 #'  Default is 0, which prompts the user for the next plot to be displayed.
 #' @param xlab label for x-axis
 #' @param ylab label for y-axis
-#' @param subtitle if TRUE, shows plot type as sub-title
+#' @param subtitle if \code{TRUE}, shows plot type as sub-title
 #' @param \dots other graphical parameters, passed to the plotting functions
 #'   (\code{plot}, \code{hist}, \code{lines}, \code{points}, etc)
 #' @return NULL
 #' @author Jeff Laake, Jon Bishop, David Borchers
 #' @keywords plot
 plot.trial <- function(x, which=1:2, breaks=NULL, nc=NULL, maintitle="",
-                       showlines=TRUE,showpoints=TRUE, ylim=c(0,1),angle=-45,
-                       density=20,col="black",jitter=NULL,divisions=25,pages=0,
-                       xlab="Distance",ylab="Detection probability",
-                       subtitle=TRUE,...){
+                       showlines=TRUE, showpoints=TRUE, ylim=c(0, 1),
+                       angle=NULL, density=NULL ,col="lightgrey", jitter=NULL,
+                       divisions=25, pages=0,
+                       xlab="Distance", ylab="Detection probability",
+                       subtitle=TRUE, ...){
   # Uses: detfct, plot_cond, plot_uncond
 
   model <- x

--- a/R/plot.trial.fi.R
+++ b/R/plot.trial.fi.R
@@ -26,15 +26,15 @@
 #' @param breaks user define breakpoints
 #' @param nc number of equal-width bins for histogram
 #' @param maintitle main title line for each plot
-#' @param showpoints logical variable; if TRUE plots predicted value for each
+#' @param showpoints logical variable; if \code{TRUE} plots predicted value for each
 #'   observation
-#' @param showlines logical variable; if TRUE a line representing the average
+#' @param showlines logical variable; if \code{TRUE} a line representing the average
 #'   detection probability is plotted
-#' @param ylim range of y axis; defaults to (0,1)
-#' @param angle shading angle for hatching
-#' @param density shading density for hatching
-#' @param col plotting colour
-#' @param jitter scaling option for plotting points.  Jitter is applied to
+#' @param ylim range of vertical axis; defaults to (0,1)
+#' @param angle shading angle for histogram bars.
+#' @param density shading density for histogram bars.
+#' @param col colour for histogram bars.
+#' @param jitter scaling option for plotting points. Jitter is applied to
 #'   points by multiplying the fitted value by a random draw from a normal
 #'   distribution with mean 1 and sd jitter.
 #' @param divisions number of divisions for averaging line values; default = 25
@@ -50,10 +50,10 @@
 #' @author Jeff Laake, Jon Bishop, David Borchers
 #' @keywords plot
 plot.trial.fi <- function(x, which=1:2, breaks=NULL, nc=NULL, maintitle="",
-                          showlines=TRUE, showpoints=TRUE, ylim=c(0,1),
-                          angle=-45,density=20,col="black",jitter=NULL,
-                          divisions=25,pages=0,xlab="Distance",
-                          ylab="Detection probability",subtitle=TRUE,...){
+                          showlines=TRUE, showpoints=TRUE, ylim=c(0, 1),
+                          angle=NULL, density=NULL, col="lightgrey",
+                          jitter=NULL, divisions=25, pages=0, xlab="Distance",
+                          ylab="Detection probability", subtitle=TRUE, ...){
 
   # Functions used: process.data, predict(predict.trial.fi), plot_uncond,
   #                 plot.cond

--- a/man/plot.det.tables.Rd
+++ b/man/plot.det.tables.Rd
@@ -7,10 +7,10 @@
 \method{plot}{det.tables}(
   x,
   which = 1:6,
-  angle = -45,
-  density = 20,
-  col1 = "black",
-  col2 = "blue",
+  angle = NULL,
+  density = NULL,
+  col1 = "white",
+  col2 = "lightgrey",
   new = TRUE,
   ...
 )
@@ -24,12 +24,11 @@
 
 \item{density}{shading density for hatching}
 
-\item{col1}{plotting colour for observer 1 detections}
+\item{col1}{plotting colour for total histogram bars.}
 
-\item{col2}{plotting colour for observer 2 detections within observer 1
-subset detections}
+\item{col2}{plotting colour for subset histogram bars.}
 
-\item{new}{if TRUE new plotting window for each plot}
+\item{new}{if \code{TRUE} new plotting window for each plot}
 
 \item{\dots}{other graphical parameters, passed to plotting functions}
 }
@@ -40,6 +39,17 @@ Just plots.
 Plot the tables created by \code{\link{det.tables}}. Produces a series of
 tables for dual observer data that shows the number missed and detected for
 each observer within defined distance classes.
+}
+\details{
+Plots that are produced are as follows (controlled by the \code{which} argument):
+\describe{
+  \item{1}{Detected by either observer/Detected by observer 1}
+  \item{2}{Detected by either observer/Detected by observer 2}
+  \item{3}{Seen by both observers}
+  \item{4}{Seen by either observer}
+  \item{5}{Detected by observer 2/Detected by observer 1 | 2}
+  \item{6}{Detected by observer 1/Detected by observer 2 | 1}
+}
 }
 \examples{
 \donttest{
@@ -57,5 +67,5 @@ plot(tabs,which=1:6,new=FALSE)
 }
 }
 \author{
-Jeff Laake
+Jeff Laake, David L Miller
 }

--- a/man/plot.ds.Rd
+++ b/man/plot.ds.Rd
@@ -12,11 +12,9 @@
   jitter.v = rep(0, 3),
   showpoints = TRUE,
   subset = NULL,
-  pl.col = "black",
-  bw.col = grey(0),
-  black.white = FALSE,
-  pl.den = rep(20, 1),
-  pl.ang = rep(-45, 1),
+  pl.col = "lightgrey",
+  pl.den = NULL,
+  pl.ang = NULL,
   main = NULL,
   pages = 0,
   pdf = FALSE,
@@ -37,33 +35,29 @@
 
 \item{nc}{number of equal width bins for histogram}
 
-\item{jitter.v}{scaling option for plotting points.  Jitter is applied to points by multiplying the fitted value by a random draw from a normal distribution with mean 1 and sd \code{jitter.v[j]}.  Where \code{j=1,2} corresponds to observer \code{j} and \code{j=3} corresponds to pooled/duplicate detections.}
+\item{jitter.v}{apply jitter to points by multiplying the fitted value by a random draw from a normal distribution with mean 1 and sd \code{jitter.v}.}
 
-\item{showpoints}{logical variable; if \code{TRUE} plots predicted value for each observation.}
+\item{showpoints}{logical variable; if \code{TRUE} plots predicted value for each observation (conditional on its observed distance).}
 
 \item{subset}{subset of data to plot.}
 
-\item{pl.col}{colours plotting colours for obs 1, obs 2 detections.}
+\item{pl.col}{colour for histogram bars.}
 
-\item{bw.col}{grayscale plotting colours for obs 1, obs 2 detections.}
+\item{pl.den}{shading density for histogram bars.}
 
-\item{black.white}{logical variable; if \code{TRUE} plots are grayscale.}
+\item{pl.ang}{shading angle for histogram bars.}
 
-\item{pl.den}{shading density for plots of obs 1, obs 2 detections.}
-
-\item{pl.ang}{shading angle for plots of obs 1, obs 2 detections.}
-
-\item{main}{user-specified plot title.}
+\item{main}{plot title.}
 
 \item{pages}{the number of pages over which to spread the plots. For example, if \code{pages=1} then all plots will be displayed on one page. Default is 0, which prompts the user for the next plot to be displayed.}
 
 \item{pdf}{plot the histogram of distances with the PDF of the probability of detection overlaid. Ignored (with warning) for line transect models.}
 
-\item{ylim}{user-specified y axis limits.}
+\item{ylim}{vertical axis limits.}
 
-\item{xlab}{label for the x axis (defaults to "Distance")}
+\item{xlab}{horizontal axis label (defaults to "Distance").}
 
-\item{ylab}{label for the y axis (default automatically sets depending on plot type)}
+\item{ylab}{vertical axis label (default automatically set depending on plot type).}
 
 \item{\dots}{other graphical parameters, passed to the plotting functions (\code{\link{plot}}, \code{\link{hist}}, \code{\link{lines}}, \code{\link{points}}, etc).}
 }
@@ -97,6 +91,9 @@ plot(xx, breaks=c(0, 0.5, 1, 2, 3, 4), subset=sex==1)
 # put both plots on one page
 plot(xx, breaks=c(0, 0.5, 1, 2, 3, 4), pages=1, which=1:2)
 }
+}
+\seealso{
+add_df_covar_line
 }
 \author{
 Jeff Laake, Jon Bishop, David Borchers, David L Miller

--- a/man/plot.io.Rd
+++ b/man/plot.io.Rd
@@ -59,7 +59,7 @@ observation}
 
 \item{col}{colour for histogram bars.}
 
-\item{jitter}{scaling option for plotting points.  Jitter is applied to
+\item{jitter}{scaling option for plotting points. Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal
 distribution with mean 1 and sd jitter.}
 

--- a/man/plot.io.Rd
+++ b/man/plot.io.Rd
@@ -14,9 +14,9 @@ sampling independent observer (\code{io}) model}
   showlines = TRUE,
   showpoints = TRUE,
   ylim = c(0, 1),
-  angle = -45,
-  density = 20,
-  col = "black",
+  angle = NULL,
+  density = NULL,
+  col = "lightgrey",
   jitter = NULL,
   divisions = 25,
   pages = 0,
@@ -51,13 +51,13 @@ detection probability is plotted}
 \item{showpoints}{logical variable; if TRUE plots predicted value for each
 observation}
 
-\item{ylim}{range of y axis; defaults to (0,1)}
+\item{ylim}{range of vertical axis; defaults to (0,1)}
 
-\item{angle}{shading angle for hatching}
+\item{angle}{shading angle for histogram bars.}
 
-\item{density}{shading density for hatching}
+\item{density}{shading density for histogram bars.}
 
-\item{col}{plotting colour}
+\item{col}{colour for histogram bars.}
 
 \item{jitter}{scaling option for plotting points.  Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal

--- a/man/plot.io.fi.Rd
+++ b/man/plot.io.fi.Rd
@@ -14,9 +14,9 @@ sampling independent observer model with full independence (\code{io.fi})}
   showlines = TRUE,
   showpoints = TRUE,
   ylim = c(0, 1),
-  angle = -45,
-  density = 20,
-  col = "black",
+  angle = NULL,
+  density = NULL,
+  col = "lightgrey",
   jitter = NULL,
   divisions = 25,
   pages = 0,
@@ -51,13 +51,13 @@ detection probability is plotted}
 \item{showpoints}{logical variable; if TRUE plots predicted value for each
 observation}
 
-\item{ylim}{range of y axis; defaults to (0,1)}
+\item{ylim}{range of vertical axis; defaults to (0,1)}
 
-\item{angle}{shading angle for hatching}
+\item{angle}{shading angle for histogram bars.}
 
-\item{density}{shading density for hatching}
+\item{density}{shading density for histogram bars.}
 
-\item{col}{plotting colour}
+\item{col}{colour for histogram bars.}
 
 \item{jitter}{scaling option for plotting points.  Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal

--- a/man/plot.rem.Rd
+++ b/man/plot.rem.Rd
@@ -14,9 +14,9 @@ sampling model}
   showlines = TRUE,
   showpoints = TRUE,
   ylim = c(0, 1),
-  angle = -45,
-  density = 20,
-  col = "black",
+  angle = NULL,
+  density = NULL,
+  col = "lightgrey",
   jitter = NULL,
   divisions = 25,
   pages = 0,
@@ -40,19 +40,19 @@ sampling model}
 
 \item{maintitle}{main title line for each plot}
 
-\item{showlines}{logical variable; if TRUE a line representing the average
+\item{showlines}{logical variable; if \code{TRUE} a line representing the average
 detection probability is plotted}
 
-\item{showpoints}{logical variable; if TRUE plots predicted value for each
+\item{showpoints}{logical variable; if \code{TRUE} plots predicted value for each
 observation}
 
-\item{ylim}{range of y axis; defaults to (0,1)}
+\item{ylim}{range of vertical axis; defaults to (0,1)}
 
-\item{angle}{shading angle for hatching}
+\item{angle}{shading angle for histogram bars.}
 
-\item{density}{shading density for hatching}
+\item{density}{shading density for histogram bars.}
 
-\item{col}{plotting colour}
+\item{col}{colour for histogram bars.}
 
 \item{jitter}{scaling option for plotting points.  Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal
@@ -68,7 +68,7 @@ Default is 0, which prompts the user for the next plot to be displayed.}
 
 \item{ylab}{label for y-axis}
 
-\item{subtitle}{if TRUE, shows plot type as sub-title}
+\item{subtitle}{if \code{TRUE}, shows plot type as sub-title}
 
 \item{\dots}{other graphical parameters, passed to the plotting functions
 (\code{plot}, \code{hist}, \code{lines}, \code{points}, etc)}

--- a/man/plot.rem.fi.Rd
+++ b/man/plot.rem.fi.Rd
@@ -14,9 +14,9 @@ sampling model}
   showlines = TRUE,
   showpoints = TRUE,
   ylim = c(0, 1),
-  angle = -45,
-  density = 20,
-  col = "black",
+  angle = NULL,
+  density = NULL,
+  col = "lightgrey",
   jitter = NULL,
   divisions = 25,
   pages = 0,
@@ -40,19 +40,19 @@ sampling model}
 
 \item{maintitle}{main title line for each plot}
 
-\item{showlines}{logical variable; if TRUE a line representing the average
+\item{showlines}{logical variable; if \code{TRUE} a line representing the average
 detection probability is plotted}
 
-\item{showpoints}{logical variable; if TRUE plots predicted value for each
+\item{showpoints}{logical variable; if \code{TRUE} plots predicted value for each
 observation}
 
-\item{ylim}{range of y axis; defaults to (0,1)}
+\item{ylim}{range of vertical axis; defaults to (0,1)}
 
-\item{angle}{shading angle for hatching}
+\item{angle}{shading angle for histogram bars.}
 
-\item{density}{shading density for hatching}
+\item{density}{shading density for histogram bars.}
 
-\item{col}{plotting colour}
+\item{col}{colour for histogram bars.}
 
 \item{jitter}{scaling option for plotting points.  Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal
@@ -68,7 +68,7 @@ Default is 0, which prompts the user for the next plot to be displayed.}
 
 \item{ylab}{label for y-axis}
 
-\item{subtitle}{if TRUE, shows plot type as sub-title}
+\item{subtitle}{if \code{TRUE}, shows plot type as sub-title}
 
 \item{\dots}{other graphical parameters, passed to the plotting functions
 (\code{plot}, \code{hist}, \code{lines}, \code{points}, etc)}

--- a/man/plot.trial.Rd
+++ b/man/plot.trial.Rd
@@ -14,9 +14,9 @@ sampling trial observer model}
   showlines = TRUE,
   showpoints = TRUE,
   ylim = c(0, 1),
-  angle = -45,
-  density = 20,
-  col = "black",
+  angle = NULL,
+  density = NULL,
+  col = "lightgrey",
   jitter = NULL,
   divisions = 25,
   pages = 0,
@@ -39,21 +39,21 @@ sampling trial observer model}
 
 \item{maintitle}{main title line for each plot}
 
-\item{showlines}{logical variable; if TRUE a line representing the average
+\item{showlines}{logical variable; if \code{TRUE} a line representing the average
 detection probability is plotted}
 
-\item{showpoints}{logical variable; if TRUE plots predicted value for each
+\item{showpoints}{logical variable; if \code{TRUE} plots predicted value for each
 observation}
 
-\item{ylim}{range of y axis; defaults to (0,1)}
+\item{ylim}{range of vertical axis; defaults to (0,1)}
 
-\item{angle}{shading angle for hatching}
+\item{angle}{shading angle for histogram bars.}
 
-\item{density}{shading density for hatching}
+\item{density}{shading density for histogram bars.}
 
-\item{col}{plotting colour}
+\item{col}{colour for histogram bars.}
 
-\item{jitter}{scaling option for plotting points.  Jitter is applied to
+\item{jitter}{scaling option for plotting points. Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal
 distribution with mean 1 and sd jitter.}
 
@@ -67,7 +67,7 @@ Default is 0, which prompts the user for the next plot to be displayed.}
 
 \item{ylab}{label for y-axis}
 
-\item{subtitle}{if TRUE, shows plot type as sub-title}
+\item{subtitle}{if \code{TRUE}, shows plot type as sub-title}
 
 \item{\dots}{other graphical parameters, passed to the plotting functions
 (\code{plot}, \code{hist}, \code{lines}, \code{points}, etc)}

--- a/man/plot.trial.fi.Rd
+++ b/man/plot.trial.fi.Rd
@@ -14,9 +14,9 @@ sampling trial observer model}
   showlines = TRUE,
   showpoints = TRUE,
   ylim = c(0, 1),
-  angle = -45,
-  density = 20,
-  col = "black",
+  angle = NULL,
+  density = NULL,
+  col = "lightgrey",
   jitter = NULL,
   divisions = 25,
   pages = 0,
@@ -39,21 +39,21 @@ sampling trial observer model}
 
 \item{maintitle}{main title line for each plot}
 
-\item{showlines}{logical variable; if TRUE a line representing the average
+\item{showlines}{logical variable; if \code{TRUE} a line representing the average
 detection probability is plotted}
 
-\item{showpoints}{logical variable; if TRUE plots predicted value for each
+\item{showpoints}{logical variable; if \code{TRUE} plots predicted value for each
 observation}
 
-\item{ylim}{range of y axis; defaults to (0,1)}
+\item{ylim}{range of vertical axis; defaults to (0,1)}
 
-\item{angle}{shading angle for hatching}
+\item{angle}{shading angle for histogram bars.}
 
-\item{density}{shading density for hatching}
+\item{density}{shading density for histogram bars.}
 
-\item{col}{plotting colour}
+\item{col}{colour for histogram bars.}
 
-\item{jitter}{scaling option for plotting points.  Jitter is applied to
+\item{jitter}{scaling option for plotting points. Jitter is applied to
 points by multiplying the fitted value by a random draw from a normal
 distribution with mean 1 and sd jitter.}
 


### PR DESCRIPTION
This brings `mrds` plots in line with changes in R 4.0.0, removing hatching and making the default fill be grey.

In summary:

 - Colourschemes now in line with R 4.0.0 for `plot.ds`, `plot.io`, `plot.io.fi`, `plot.rem`, `plot.rem.fi`, `plot.trail`, `plot.trail.fi` and `plot.det.tables` . Bars are now `"lightgrey"`, no hatching. This will need to be propagated to `Distance` in the next release for `plot.ds`/`mrds::plot.dsmodel`.
- `plot.ds`: remove `black.white` and `bw.col` arguments since you can just set the colours. Internal logic didn't seem to do anything that couldn't be done by setting the colours anyway.
- `plot.ds`: remove documentation entries regarding different observers. This codes never seems to have been implemented so documentation was misleading.
- `plot.ds`: clarified other argument documentation
- `plot.det.tables`: clarify `which` argument documentation, update other argument documentation.

Let me know what you think of these changes and I will roll them into the package for next release. I don't think these are breaking changes for the next Distance for Windows release.