### PR TITLE
Variable strip widths

### DIFF
--- a/R/apex.gamma.R
+++ b/R/apex.gamma.R
@@ -5,8 +5,8 @@
 #' @return the distance at which the gamma peaks
 #' @author Jeff Laake
 apex.gamma <- function(ddfobj){
-  key.scale <- scalevalue(ddfobj$scale$parameters,ddfobj$scale$dm)
-  key.shape <- scalevalue(ddfobj$shape$parameters,ddfobj$shape$dm)
+  key.scale <- scalevalue(ddfobj$scale$parameters, ddfobj$scale$dm)
+  key.shape <- scalevalue(ddfobj$shape$parameters, ddfobj$shape$dm)
 
   fr <- (1/gamma(key.shape)) * (((key.shape - 1)/exp(1))^(key.shape - 1))
   return(key.scale*fr*(key.shape-1))

--- a/R/ddf.R
+++ b/R/ddf.R
@@ -137,7 +137,7 @@
 #' the transect width (and the left truncation point if there is a blindspot
 #' below the aircraft) can potentially change for each observation. The
 #' argument \code{int.range} can also be entered as a matrix with 2 columns
-#' (left and width) and a row for each observation. 
+#' (left and width) and a row for each observation.
 #'
 #' The argument \code{control} is a list that enables various analysis options
 #' to be set.  It is not necessary to set any of these for most analyses.  They

--- a/R/detfct.R
+++ b/R/detfct.R
@@ -108,7 +108,6 @@ distpdf <- function(distance, ddfobj, select=NULL, index=NULL, width=NULL,
              width=width, standardize=standardize, stdint=stdint))
 }
 
-
 fx <- function(distance, ddfobj, select=NULL, index=NULL, width=NULL,
                standardize=TRUE, stdint=FALSE, left=0){
   return(detfct(distance, ddfobj, select, index, width, standardize, stdint)/
@@ -120,7 +119,6 @@ fr <- function(distance, ddfobj, select=NULL, index=NULL, width=NULL,
   return(detfct(distance, ddfobj, select, index, width, standardize, stdint)*
          2*distance/width^2)
 }
-
 
 detfct <- function(distance, ddfobj, select=NULL, index=NULL, width=NULL,
                    standardize=TRUE, stdint=FALSE, left=0){
@@ -227,7 +225,7 @@ detfct <- function(distance, ddfobj, select=NULL, index=NULL, width=NULL,
     # this cancels in the likelihood, so we don't need it in optimisation
     if(standardize){
       if(key == "gamma"){
-        # for the gammma, use apex.gamma to find the apex first, then eval
+        # for the gamma, use apex.gamma to find the apex first, then eval
         # need to update the scale to be +1 in this apex call
         ddfobj$shape$parameters <- log(exp(ddfobj$shape$parameters)+1)
         zeros <- as.vector(apex.gamma(ddfobj))[1]

--- a/R/dht.deriv.R
+++ b/R/dht.deriv.R
@@ -17,7 +17,7 @@
 #' @author Jeff Laake
 #' @seealso \code{\link{dht}}, \code{\link{dht.se}}, \code{\link{DeltaMethod}}
 #' @keywords utility
-dht.deriv <- function(par,model,obs,samples,options=list()){
+dht.deriv <- function(par, model, obs, samples, options=list()){
   # Functions Used:  predict, covered.region.dht, survey.region.dht
 
   #  Depending on model method store new parameter values
@@ -38,7 +38,7 @@ dht.deriv <- function(par,model,obs,samples,options=list()){
   # not what I wanted.  You would only not integrate if you didn't want to
   # assume 1/w; otherwise, always want to integrate to get average detection
   # probability
-  pdot <- predict(model,integrate=TRUE,compute=TRUE)
+  pdot <- predict(model, integrate=TRUE, compute=TRUE)
 
   if(!is.null(pdot$fitted)){
     pdot <- pdot$fitted
@@ -48,22 +48,24 @@ dht.deriv <- function(par,model,obs,samples,options=list()){
   # code below would not work if there is a pdot column there already, so remove
   obs$pdot <- NULL
 
-  obs <- merge(obs,data.frame(object=as.numeric(names(model$fitted)),pdot=pdot))
+  obs <- merge(obs, data.frame(object=as.numeric(names(model$fitted)),
+               pdot=pdot))
 
   # Compute covered region abundances by sample depending on value of group
-  Nhat.by.sample <- covered.region.dht(obs,samples,options$group)
+  Nhat.by.sample <- covered.region.dht(obs, samples, options$group)
 
   # Scale up abundances to survey region
   Nhat.by.sample <- survey.region.dht(Nhat.by.sample, samples,
                                    model$meta.data$width*options$convert.units,
                                    model$meta.data$left*options$convert.units,
-                                   model$meta.data$point)
-  Nhat.by.region <- by(Nhat.by.sample$Nhat,Nhat.by.sample$Region.Label,sum)
+                                   model$meta.data$point,
+                                   options$areas.supplied)
+  Nhat.by.region <- by(Nhat.by.sample$Nhat, Nhat.by.sample$Region.Label, sum)
 
   # Return vector of predicted abundances
 
   if(length(Nhat.by.region)>1){
-    return(c(as.vector(Nhat.by.region),sum(as.vector(Nhat.by.region))))
+    return(c(as.vector(Nhat.by.region), sum(as.vector(Nhat.by.region))))
   }else{
     return(as.vector(Nhat.by.region))
   }

--- a/R/gstdint.R
+++ b/R/gstdint.R
@@ -22,7 +22,7 @@
 #' @author Jeff Laake and David L Miller
 #' @keywords utility
 #' @importFrom stats pnorm smooth.spline
-gstdint <- function(x, ddfobj, index=NULL,select=NULL, width,
+gstdint <- function(x, ddfobj, index=NULL, select=NULL, width,
                     standardize=TRUE, point=FALSE, stdint=TRUE,
                     doeachint=FALSE, left=left){
 

--- a/R/plot.ds.R
+++ b/R/plot.ds.R
@@ -365,7 +365,7 @@ plot.ds <- function(x, which=2, breaks=NULL, nc=NULL,
         # now rescale such that area under pdf == area under histogram
         linevalues <- pdf_vals * hist_area
       }else{
-        linevalues <- detfct(xgrid, ddfobj, width=width)
+        linevalues <- detfct(xgrid, ddfobj, width=width, left=left)
       }
     }
 
@@ -378,7 +378,6 @@ plot.ds <- function(x, which=2, breaks=NULL, nc=NULL,
     ldots <- dots
     ldots$x <- xgrid
     ldots$y <- linevalues
-    #lines(xgrid, linevalues, ...)
     do.call(lines, ldots)
 
     if(showpoints){

--- a/R/survey.region.dht.R
+++ b/R/survey.region.dht.R
@@ -5,31 +5,40 @@
 #' @param width truncation width
 #' @param left left truncation if any
 #' @param point if TRUE point count otherwise line transect
+#' @param areas.supplied if \code{TRUE}, covered area is extracted from the
+#' \code{CoveredArea} column of \code{Nhat.by.sample}
 #' @return Revised Nhat.by.sample dataframe containing estimates extrapolated
 #'   to survey region
 #' @note Internal function called by \code{\link{dht}} and related functions.
-#' @author Jeff Laake
+#' @author Jeff Laake and David L Miller
 #' @keywords utility
-survey.region.dht <- function(Nhat.by.sample, samples, width, left, point){
-  #  Compute effort in each region and the area in the covered region
+survey.region.dht <- function(Nhat.by.sample, samples, width, left, point,
+                              areas.supplied){
+  #  Compute effort in each region
   Effort.by.region <- by(samples$Effort, samples$Region.Label, sum)
-  if(point){
-    CoveredArea <- pi*as.vector(Effort.by.region)*width^2 -
-                    pi*as.vector(Effort.by.region)*left^2
-  }else{
-    CoveredArea <- 2*as.vector(Effort.by.region)*(width-left)
-  }
 
+  # calculate the areas, unless they were given already
+  if(areas.supplied){
+    CoveredArea <- as.vector(by(samples$CoveredArea, samples$Region.Label, sum))
+    Nhat.by.sample$CoveredArea <- NULL
+  }else{
+    if(point){
+      CoveredArea <- pi*as.vector(Effort.by.region)*width^2 -
+                      pi*as.vector(Effort.by.region)*left^2
+    }else{
+      CoveredArea <- 2*as.vector(Effort.by.region)*(width-left)
+    }
+  }
   # Scale up abundance in covered region to the survey region
   # unless no areas given
-  Nhat.by.sample <- merge(Nhat.by.sample,
+  Nhat.by.region <- merge(Nhat.by.sample,
                           data.frame(Region.Label=names(Effort.by.region),
                                      CoveredArea=CoveredArea,
                                      Effort=as.vector(Effort.by.region)),
                           by.x="Region.Label",
                           by.y="Region.Label",
                           all.x=TRUE)
-  Nhat.by.sample$Nhat <- Nhat.by.sample$Nhat*Nhat.by.sample$Area/
-                          Nhat.by.sample$CoveredArea
-  return(Nhat.by.sample)
+  Nhat.by.region$Nhat <- Nhat.by.region$Nhat*Nhat.by.region$Area/
+                          Nhat.by.region$CoveredArea
+  return(Nhat.by.region)
 }

--- a/man/ddf.Rd
+++ b/man/ddf.Rd
@@ -168,7 +168,7 @@ analyses are truncated (i.e., the last interval does not go to infinity),
 the transect width (and the left truncation point if there is a blindspot
 below the aircraft) can potentially change for each observation. The
 argument \code{int.range} can also be entered as a matrix with 2 columns
-(left and width) and a row for each observation. 
+(left and width) and a row for each observation.
 
 The argument \code{control} is a list that enables various analysis options
 to be set.  It is not necessary to set any of these for most analyses.  They

--- a/man/dht.Rd
+++ b/man/dht.Rd
@@ -135,10 +135,12 @@ hectares (100 to convert metres to 100 metres for distance and .1 to convert
 km to 100m units).
 
 The argument \code{options} is a list of \code{variable=value} pairs that
-set options for the analysis. All but one of these has been described so
-far. The remaining variable \code{pdelta} should not need to be changed but
-was included for completeness. It controls the precision of the first
-derivative calculation for the delta method variance.
+set options for the analysis. All but two of these have been described above.
+\code{pdelta} should not need to be changed but was included for
+completeness. It controls the precision of the first derivative calculation
+for the delta method variance. If the option \code{areas.supplied} is
+\code{TRUE} then the covered area is assumed to be supplied in the
+\code{CoveredArea} column of the sample \code{data.frame}.
 }
 \section{Uncertainty}{
 

--- a/man/survey.region.dht.Rd
+++ b/man/survey.region.dht.Rd
@@ -4,7 +4,7 @@
 \alias{survey.region.dht}
 \title{Extrapolate Horvitz-Thompson abundance estimates to entire surveyed region}
 \usage{
-survey.region.dht(Nhat.by.sample, samples, width, left, point)
+survey.region.dht(Nhat.by.sample, samples, width, left, point, areas.supplied)
 }
 \arguments{
 \item{Nhat.by.sample}{dataframe of abundance by sample}
@@ -16,6 +16,9 @@ survey.region.dht(Nhat.by.sample, samples, width, left, point)
 \item{left}{left truncation if any}
 
 \item{point}{if TRUE point count otherwise line transect}
+
+\item{areas.supplied}{if \code{TRUE}, covered area is extracted from the
+\code{CoveredArea} column of \code{Nhat.by.sample}}
 }
 \value{
 Revised Nhat.by.sample dataframe containing estimates extrapolated
@@ -28,6 +31,6 @@ Extrapolate Horvitz-Thompson abundance estimates to entire surveyed region
 Internal function called by \code{\link{dht}} and related functions.
 }
 \author{
-Jeff Laake
+Jeff Laake and David L Miller
 }
 \keyword{utility}

--- a/tests/testthat/test_dht.R
+++ b/tests/testthat/test_dht.R
@@ -3,26 +3,27 @@ par.tol<-1e-6
 
 context("dht")
 
-test_that("golf tees",{
+data(book.tee.data)
+tee.data<-book.tee.data$book.tee.dataframe[book.tee.data$book.tee.dataframe$observer==1,]
+ds.model <- ddf(dsmodel=~cds(key="hn", formula=~1), data=tee.data, method="ds",
+                meta.data=list(width=4))
 
-  data(book.tee.data)
-  tee.data<-book.tee.data$book.tee.dataframe[book.tee.data$book.tee.dataframe$observer==1,]
-  ds.model <- ddf(dsmodel=~cds(key="hn", formula=~1), data=tee.data, method="ds",
-                  meta.data=list(width=4))
+# same model, but calculating abundance
+# need to supply the region, sample and observation tables
+region <- book.tee.data$book.tee.region
+samples <- book.tee.data$book.tee.samples
+obs <- book.tee.data$book.tee.obs
 
-  # same model, but calculating abundance
-  # need to supply the region, sample and observation tables
-  region <- book.tee.data$book.tee.region
-  samples <- book.tee.data$book.tee.samples
-  obs <- book.tee.data$book.tee.obs
-
+test_that("golf tees", {
 
   # check that errors are thrown when the wrong ER variance is asked for
   expect_error(dht(ds.model, region.table=region,
                    sample.table=samples, obs.table=obs,
                    options=list(ervar="P3")),
                "Encounter rate variance estimator P3 may only be used with point transects, set with options=list(ervar=...)", fixed=TRUE)
+})
 
+test_that("ptdata", {
   # fake up some pt data
   pt.sample <- data.frame(Sample.Label=1, Region.Label=1, Effort=1)
   data(ptdata.single)
@@ -39,3 +40,10 @@ test_that("golf tees",{
 
 })
 
+
+test_that("areas.supplied", {
+  samples$CoveredArea<- samples$Effort * 2 * 4
+  expect_equal(dht(ds.model, region, samples, obs,
+                   options=list(areas.supplied=TRUE)),
+               dht(ds.model, region, samples, obs))
+})


### PR DESCRIPTION
Adds support for variable strip widths via the user providing the covered area for a given sample (transect). This is only activated via the `options` argument to `dht`.

Closes #14.